### PR TITLE
Remove duplication from metric names

### DIFF
--- a/a10n/hg_elmo/utils.py
+++ b/a10n/hg_elmo/utils.py
@@ -23,7 +23,7 @@ from six.moves import range
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(message)s")
 logger = logging.getLogger()
-metrics = markus.get_metrics('elmo-hg-worker')
+metrics = markus.get_metrics('hg.worker')
 
 
 def getURL(repo, limit):

--- a/vendor-local/l10ninsp/status.py
+++ b/vendor-local/l10ninsp/status.py
@@ -10,7 +10,7 @@ from twisted.python import log
 import markus
 
 
-metrics = markus.get_metrics('elmo-builds')
+metrics = markus.get_metrics('builds')
 
 
 class MarkusStatusReceiver(StatusReceiverMultiService):


### PR DESCRIPTION
We are already prefacing all custom metrics with 'elmo'. Having that here causes it to appear in the metric name twice.

Also, markus replaces all hyphens with periods, so to avoid confusion I explicitly do that.

With this, existing metric names like elmo.elmo.hg.worker.hg_pull.avg will become elmo.hg.worker.hg_pull.avg

If we don't plan to deploy to SCL3 before the migration, we could hold off on merging this until after the migration so that we can continue to compare metrics across environments.